### PR TITLE
resumeDownload ignores options

### DIFF
--- a/lib/Downloader.js
+++ b/lib/Downloader.js
@@ -52,7 +52,9 @@ Downloader.prototype.download = function(url, filePath, options) {
     return dl;
 };
 
-Downloader.prototype.resumeDownload = function(filePath) {
+Downloader.prototype.resumeDownload = function(filePath, options) {
+    var options = extend({}, this._defaultOptions, options);
+    
     var dl = new Download();
 
     if (!filePath.match(/\.mtd$/)) {
@@ -61,7 +63,7 @@ Downloader.prototype.resumeDownload = function(filePath) {
 
     dl.setUrl(null);
     dl.setFilePath(filePath);
-    dl.setOptions({});
+    dl.setOptions(options);
 
     this._downloads.push(dl);
 


### PR DESCRIPTION
If you use a specific port for a download, it must be set in the options even if you resume a download.
