### PR TITLE
Fix/resumed download keep handle

### DIFF
--- a/lib/Download.js
+++ b/lib/Download.js
@@ -1,4 +1,4 @@
-var mtd = require('mt-downloader');
+var mtd = require('zeltice-mt-downloader');
 var fs = require('fs');
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;

--- a/lib/Download.js
+++ b/lib/Download.js
@@ -121,7 +121,7 @@ Download.prototype.setError = function(error) {
 
 Download.prototype._computeDownloaded = function() {
     if(!this.meta.threads) { return 0; }
-    
+
     var downloaded = 0;
     this.meta.threads.forEach(function(thread) {
         downloaded += thread.position - thread.start;
@@ -310,6 +310,11 @@ Download.prototype.start = function() {
 		} else {
             self._computeEndTime();
 
+          // in the case where the download is paused and resumed,
+          // it seems that more than one handle is generated / not closed
+          // and causes problem when trying to run the file after it downloaded
+          // So we destroy all the threads/handles when the download finishes
+          self._destroyThreads();
 			self.setStatus(3);
 
             self.emit('end', self);

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/leeroybrun/node-mt-files-downloader",
   "dependencies": {
     "moment": "^2.9.0",
-    "mt-downloader": "2.2.2"
+    "zeltice-mt-downloader": "1.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/leeroybrun/node-mt-files-downloader",
   "dependencies": {
     "moment": "^2.9.0",
-    "mt-downloader": "^0.2.10"
+    "mt-downloader": "2.2.2"
   }
 }


### PR DESCRIPTION
In the case where the download is paused and resumed, it seems that more than one handle is generated / not closed and causes problem when trying to run the file after it downloaded. So we destroy all the threads/handles when the download finishes.